### PR TITLE
#3 Update module name to public

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"ops-changelog/internal/formatter"
-	gh "ops-changelog/internal/github"
+	"github.com/railgun-0402/ops-changelog/internal/formatter"
+	gh "github.com/railgun-0402/ops-changelog/internal/github"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module ops-changelog
+module github.com/railgun-0402/ops-changelog
 
 go 1.26.0
 

--- a/internal/formatter/text.go
+++ b/internal/formatter/text.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	gh "ops-changelog/internal/github"
+	gh "github.com/railgun-0402/ops-changelog/internal/github"
 )
 
 // PrintPRs writes a human-readable PR list to w.

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"ops-changelog/cmd"
+	"github.com/railgun-0402/ops-changelog/cmd"
 )
 
 func main() {


### PR DESCRIPTION
## overview

Fix #3 

- Update `go.mod` module name from `ops-changelog` to `github.com/railgun-0402/ops-changelog`
- Update all internal import paths accordingly

