### PR TITLE
perf: use GitHub Search API for server-side PR filtering

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -5,12 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os/exec"
 	"strings"
 	"time"
 )
 
-const baseURL = "https://api.github.com"
+const searchURL = "https://api.github.com/search/issues"
 
 // Client is a minimal GitHub REST API client.
 type Client struct {
@@ -41,27 +42,41 @@ func tokenFromGHCLI() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// apiPR is the raw GitHub API pull request shape (subset of fields we need).
-type apiPR struct {
-	Number   int    `json:"number"`
-	Title    string `json:"title"`
-	HTMLUrl  string `json:"html_url"`
-	MergedAt string `json:"merged_at"`
-	User     struct {
+// searchIssuesResponse is the GitHub Search Issues API response shape.
+type searchIssuesResponse struct {
+	TotalCount int             `json:"total_count"`
+	Items      []searchIssuePR `json:"items"`
+}
+
+// searchIssuePR is one item from the Search Issues API (PR subset).
+type searchIssuePR struct {
+	Number  int    `json:"number"`
+	Title   string `json:"title"`
+	HTMLUrl string `json:"html_url"`
+	User    struct {
 		Login string `json:"login"`
 	} `json:"user"`
 	Labels []struct {
 		Name string `json:"name"`
 	} `json:"labels"`
+	PullRequest struct {
+		MergedAt string `json:"merged_at"`
+	} `json:"pull_request"`
 }
 
-// fetchMergedPRPage fetches one page of merged PRs (sorted by updated desc).
-// Returns the PRs, whether there are more pages, and any error.
-func (c *Client) fetchMergedPRPage(ctx context.Context, owner, repo string, page int) ([]PR, bool, error) {
-	url := fmt.Sprintf("%s/repos/%s/%s/pulls?state=closed&sort=updated&direction=desc&per_page=100&page=%d",
-		baseURL, owner, repo, page)
+// SearchMergedPRsPage fetches one page of merged PRs via GitHub Search API.
+// Filtering by repo, optional label, and merged-after time is done server-side,
+// which avoids paginating through unrelated closed PRs.
+func (c *Client) SearchMergedPRsPage(ctx context.Context, owner, repo, label string, since time.Time, page int) ([]PR, bool, error) {
+	q := fmt.Sprintf("is:pr is:merged repo:%s/%s merged:>=%s",
+		owner, repo, since.UTC().Format(time.RFC3339))
+	if label != "" {
+		q += " label:" + label
+	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	rawURL := buildSearchURL(q, page)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return nil, false, err
 	}
@@ -76,21 +91,17 @@ func (c *Client) fetchMergedPRPage(ctx context.Context, owner, repo string, page
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, false, fmt.Errorf("GitHub API returned %d for %s/%s", resp.StatusCode, owner, repo)
+		return nil, false, fmt.Errorf("GitHub Search API returned %d for %s/%s", resp.StatusCode, owner, repo)
 	}
 
-	var raw []apiPR
+	var raw searchIssuesResponse
 	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
 		return nil, false, err
 	}
 
-	var prs []PR
-	for _, r := range raw {
-		// Skip unmerged closed PRs
-		if r.MergedAt == "" {
-			continue
-		}
-		mergedAt, err := time.Parse(time.RFC3339, r.MergedAt)
+	prs := make([]PR, 0, len(raw.Items))
+	for _, r := range raw.Items {
+		mergedAt, err := time.Parse(time.RFC3339, r.PullRequest.MergedAt)
 		if err != nil {
 			continue
 		}
@@ -108,6 +119,17 @@ func (c *Client) fetchMergedPRPage(ctx context.Context, owner, repo string, page
 		})
 	}
 
-	hasMore := len(raw) == 100
+	hasMore := len(raw.Items) == 100
 	return prs, hasMore, nil
+}
+
+// buildSearchURL constructs the search API URL with properly encoded query parameters.
+func buildSearchURL(q string, page int) string {
+	params := url.Values{}
+	params.Set("q", q)
+	params.Set("sort", "created")
+	params.Set("direction", "desc")
+	params.Set("per_page", "100")
+	params.Set("page", fmt.Sprintf("%d", page))
+	return searchURL + "?" + params.Encode()
 }

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -3,7 +3,6 @@ package github
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 )
 
@@ -26,31 +25,24 @@ type ListMergedPRsOptions struct {
 }
 
 // ListMergedPRs fetches merged PRs filtered by service label and merged-after time.
+// It uses the GitHub Search API to filter server-side, avoiding full pagination
+// through all closed PRs.
 func (c *Client) ListMergedPRs(ctx context.Context, opts ListMergedPRsOptions) ([]PR, error) {
-	var targetLabel string
+	var label string
 	if opts.Service != "" {
-		targetLabel = fmt.Sprintf("service:%s", opts.Service)
+		label = fmt.Sprintf("service:%s", opts.Service)
 	}
 
 	var result []PR
 	page := 1
 
 	for {
-		prs, hasMore, err := c.fetchMergedPRPage(ctx, opts.Owner, opts.Repo, page)
+		prs, hasMore, err := c.SearchMergedPRsPage(ctx, opts.Owner, opts.Repo, label, opts.Since, page)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, pr := range prs {
-			// Stop pagination once we go past the since boundary
-			if pr.MergedAt.Before(opts.Since) {
-				return result, nil
-			}
-
-			if targetLabel == "" || hasLabel(pr.Labels, targetLabel) {
-				result = append(result, pr)
-			}
-		}
+		result = append(result, prs...)
 
 		if !hasMore {
 			break
@@ -59,13 +51,4 @@ func (c *Client) ListMergedPRs(ctx context.Context, opts ListMergedPRsOptions) (
 	}
 
 	return result, nil
-}
-
-func hasLabel(labels []string, target string) bool {
-	for _, l := range labels {
-		if strings.EqualFold(l, target) {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Summary

- `GET /repos/{owner}/{repo}/pulls` (全クローズドPRを取得してクライアント側でフィルタ) から GitHub Search API に切り替え
- クエリ: `is:pr is:merged repo:{owner}/{repo} merged:>={since} label:{label}` でサーバー側フィルタリング
- PRが多いリポジトリほど API コール数・転送量が大幅に削減される
- 不要になった `hasLabel`・`fetchMergedPRPage` を削除

## 改善の背景

旧実装の問題点:
1. `sort=updated` でソートして `merged_at` でクライアント側にフィルタ → 更新日とmerge日のズレで早期終了が不正確になるケースがあった
2. ラベルフィルタもクライアント側 → マッチしないPRのデータを大量にフェッチしていた

## Test plan

- [x] `go build ./...` が通ること
- [x] `go test ./...` が通ること
- [ ] 実リポジトリで `ops-changelog list --repo <owner/repo> --service <svc> --since 24h` の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)